### PR TITLE
feat: Only do `CI` GHA on push to `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR scopes the `CI` GitHub Action to only run when a push is made to the `master` branch.